### PR TITLE
Fixed expanding/collapsing of Meetup Listing

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,11 @@
       "name": "Will Laurance",
       "github": "wlaurance",
       "email": "w.laurance@gmail.com"
+    },
+    {
+      "name": "Jon Keam",
+      "github": "jkeam",
+      "email": "jpkeam@gmail.com"
     }
   ],
   "license": "MIT",

--- a/public/ng/controllers.js
+++ b/public/ng/controllers.js
@@ -31,18 +31,21 @@ angular.module('nodeDC.controllers', [])
     })
     .controller('MeetupsCtrl', function ($scope, $http) {
         'use strict';
-        $scope.toggleDescription = false;
         $http({
             method: 'GET',
             url: '/api/meetups'
         })
         .success(function (data) {
-            $scope.meetups = data.results;
+            var results = data.results;
+            if (results) {
+                results.forEach(function(result) {
+                    result.visible = false;
+                });
+            }
+
+            $scope.meetups = results;
         });
-        $scope.showDescription = function () {
-          $scope.toggleDescription = true;
-        };
-        $scope.hideDescription = function () {
-          $scope.toggleDescription = false;
+        $scope.toggleVisibility = function (meetup) {
+            meetup.visible = !meetup.visible;
         };
     });

--- a/views/partials/partialMeetups.jade
+++ b/views/partials/partialMeetups.jade
@@ -6,9 +6,9 @@ div(ng-controller='MeetupsCtrl')
                 li(class="list-group-item")
                     a(href="{{ meetup.event_url }}")<b>{{meetup.name }}</b>
                     |  @ {{meetup.venue.name}}<br /><em>{{ meetup.time | date:'medium' }}</em>
-                    a(ng-click="showDescription()" ng-hide="toggleDescription")<i class="fa fa-plus pull-right"></i>
-                    a(ng-click="hideDescription()" ng-show="toggleDescription")<i class="fa fa-minus pull-right"></i>
-                li(class="list-group-item" ng-show="toggleDescription")
+                    a(ng-click="toggleVisibility(meetup)" ng-hide="meetup.visible")<i class="fa fa-plus pull-right"></i>
+                    a(ng-click="toggleVisibility(meetup)" ng-show="meetup.visible")<i class="fa fa-minus pull-right"></i>
+                li(class="list-group-item" ng-show="meetup.visible")
                     p
                         b Description:
                     blockquote


### PR DESCRIPTION
When I click on a particular element on the Meetup Listing to view the details of a particular meetup, they all open instead of just the one I wanted to see.  This is unexpected and very unfriendly.  I'm forced to scroll through the entire list of meetups I potentially don't care about to find the one I want.

This PR addresses that issue by adding the visible attribute on each meetup element so that they can all independently hold their own state instead of sharing the single controller state, which is what it was doing before.